### PR TITLE
Allow rendering emojis when not surrounded by spaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 composer.lock
 phpunit.xml
 vendor
-.idea
 .phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 composer.lock
 phpunit.xml
 vendor
+.idea
+.phpunit.result.cache

--- a/src/EmojiParser.php
+++ b/src/EmojiParser.php
@@ -75,11 +75,6 @@ class EmojiParser implements InlineParserInterface
     {
         $cursor = $inlineContext->getCursor();
 
-        $previous = $cursor->peek(-1);
-        if ($previous !== null && $previous !== ' ') {
-            return false;
-        }
-
         $saved = $cursor->saveState();
 
         $cursor->advance();
@@ -87,14 +82,6 @@ class EmojiParser implements InlineParserInterface
         $handle = $cursor->match('/^[a-z0-9\+\-_]+:/');
 
         if (!$handle) {
-            $cursor->restoreState($saved);
-
-            return false;
-        }
-
-        $next = $cursor->peek(0);
-
-        if ($next !== null && $next !== ' ') {
             $cursor->restoreState($saved);
 
             return false;

--- a/tests/EmojiParserTest.php
+++ b/tests/EmojiParserTest.php
@@ -30,9 +30,10 @@ class EmojiParserTest extends AbstractTestCase
             [':+1:', '<p><img class="emoji" data-emoji="+1" src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f44d.png?v5" alt="+1" /></p>'],
             ['* :airplane:', "<ul>\n<li>\n<img class=\"emoji\" data-emoji=\"airplane\" src=\"https://assets-cdn.github.com/images/icons/emoji/unicode/2708.png?v5\" alt=\"airplane\" />\n</li>\n</ul>"],
             ['foo bar baz: lol', '<p>foo bar baz: lol</p>'],
-            [':+1:123', '<p>:+1:123</p>'],
+            [':+1:123', '<p><img class="emoji" data-emoji="+1" src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f44d.png?v5" alt="+1" />123</p>'],
             [':123123123:', '<p>:123123123:</p>'],
             [':+1 :', '<p>:+1 :</p>'],
+            [':+1::+1:', '<p><img class="emoji" data-emoji="+1" src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f44d.png?v5" alt="+1" /><img class="emoji" data-emoji="+1" src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f44d.png?v5" alt="+1" /></p>'],
             [':8ball: :100:', '<p><img class="emoji" data-emoji="8ball" src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f3b1.png?v5" alt="8ball" /> <img class="emoji" data-emoji="100" src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f4af.png?v5" alt="100" /></p>'],
         ];
     }


### PR DESCRIPTION
GFM allows rendering emojis without requiring the markers to be surrounded by spaces, even so, you can render multiple emojis continuously.

The current implementation of this extension doesn't allow emojis to be rendered if they are not surrounded by spaces.

Look at the following table for comparison:

| MD String | CachetHQ's Render | Github Render |
| - | - | - |
| `:+1:123` | ![image](https://user-images.githubusercontent.com/4632429/71751304-c1a7b680-2e40-11ea-9eb8-65ba8ed50048.png) | :+1:123 |
| `:+1::+1:` | ![image](https://user-images.githubusercontent.com/4632429/71751320-d126ff80-2e40-11ea-8d95-18b82b2b117e.png) | :+1::+1: |
| `¡Viva Mexico :mexico:!` | ![image](https://user-images.githubusercontent.com/4632429/71751336-e00db200-2e40-11ea-8adc-d02c3208c57c.png) | ¡Viva Mexico :mexico:! |

Hope you agree to merge this :open_hands:.